### PR TITLE
Make _super call backwards compatible.

### DIFF
--- a/ember-addon.js
+++ b/ember-addon.js
@@ -3,7 +3,7 @@ var path = require('path');
 module.exports = {
   name: 'layout-bin-packer',
   init: function () {
-    this._super.apply(this, arguments);
+    this._super.init && this._super.init.apply(this, arguments);
     this.treePaths.addon = 'lib/layout-bin-packer';
   },
   treeFor: function (name) {


### PR DESCRIPTION
The change added in https://github.com/stefanpenner/layout-bin-packer/pull/20 was incompatible with ember-cli@2.5.0. 

`this._super` is not a function until at least ember-cli@2.6.0-beta.1 (due to core-object@2 usage), but `this._super.init` was present in both older core-object versions and newer ones.

@stefanpenner - r?
