### PR TITLE
don't try to find the entry at NaN

### DIFF
--- a/lib/layout-bin-packer/shelf-first.js
+++ b/lib/layout-bin-packer/shelf-first.js
@@ -205,6 +205,8 @@ ShelfFirst.prototype.visibleStartingIndex = function (topOffset, width, visibleH
   var height = this.height();
   var length = this.length();
 
+  if (length === 0) { return 0; }
+
   // Start searching using the last item in the list
   // and the bottom of the list for calculating the average height.
 


### PR DESCRIPTION
I ran into some trouble porting our multi-select input (see screenshot; hopefully you can imagine what it's meant to do) to use ember-collection and I tracked the problem down to this.

If `length` is `0`, then we end up [dividing by zero](https://github.com/stefanpenner/layout-bin-packer/blob/master/lib/layout-bin-packer/shelf-first.js#L227) which will evaluate to either `Infinity` or `NaN`, neither of which will work with `_entryAt`.

This PR seems to solve my problem by returning early in the case that `length` is `0`, thus avoiding [throwing a type error](https://github.com/stefanpenner/layout-bin-packer/blob/master/lib/layout-bin-packer/shelf-first.js#L236).

<img width="857" alt="screen shot 2016-06-21 at 15 21 53" src="https://cloud.githubusercontent.com/assets/575266/16248435/fbe7a21e-37c3-11e6-8f5a-dfafdbed968d.png">
