### PR TITLE
Depend on ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "qunit-extras": "^1.4.2",
     "qunitjs": "^1.18.0",
     "rollup": "^0.14.1"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^5.2.4"
   }
 }


### PR DESCRIPTION
I know you're on vacation right now, but wanted to open this while I was thinking about it. It looks like this was relying on implicit transpilation of its `addon` tree, which is (I realize I'm preaching to the choir) deprecated in CLI 2.12.
