### PR TITLE
rebase of: fix shelf-first visibleStartingIndex for empty content

### DIFF
--- a/lib/layout-bin-packer/shelf-first.js
+++ b/lib/layout-bin-packer/shelf-first.js
@@ -204,6 +204,7 @@ export default class ShelfFirst extends Bin {
 
     const height = this.height();
     const length = this.length();
+    if (length <= 1) { return 0; }
 
     // Start searching using the last item in the list
     // and the bottom of the list for calculating the average height.

--- a/tests/index.js
+++ b/tests/index.js
@@ -186,6 +186,22 @@
     });
   });
 
+  var contentC = [
+    /*0*/{ height:  50, width: 100 },
+    /*1*/{ height: 100, width: 100 },
+    /*2*/{ height:  50, width: 100 },
+  ];
+
+  test('test empty state with shelf first', function (assert) {
+    var bin = new Bin.ShelfFirst(contentC, 100);
+    assert.equal(bin.visibleStartingIndex(50, 100, 100), 1);
+    contentC.splice(0, contentC.length - 1);
+    assert.equal(bin.visibleStartingIndex(50, 100, 100), 0);
+    assert.equal(bin.visibleStartingIndex(1000, 100, 100), 0);
+    contentC.splice(0, contentC.length);
+    assert.equal(bin.visibleStartingIndex(1000, 100, 100), 0);
+  });
+
   QUnit.module('FixedGrid');
 
   test('testing fixed grid', function(assert) {


### PR DESCRIPTION
Fixes: #26

I think because https://github.com/stefanpenner/layout-bin-packer/pull/32 is master, I cannot push to it to rebase it.